### PR TITLE
カテゴリ/タグ一覧ページ作成、リンクデザイン変更

### DIFF
--- a/_includes/aside.html
+++ b/_includes/aside.html
@@ -18,5 +18,12 @@
       {% endfor %}
       </p>
     </div>
+    <div class="aside-tags">
+      <p>:pencil: タグ一覧</p>
+      {% for tag in site.tags%}
+        {% capture tag_name %}{{ tag | first }}{% endcapture %}
+        <a href="{{site.baseurl}}/tags/index#{{ tag_name}}" class="aside-link">#{{ tag_name | capitalize }}</a>
+      {% endfor %}
+    </div>
   </div>
 </aside>

--- a/_includes/aside.html
+++ b/_includes/aside.html
@@ -8,15 +8,17 @@
       {% for post in site.posts limit:15 %}
       <div class="aside-recent-item">:carrot:&nbsp;<a href="{{ post.url }}" class="aside-link">{{ post.title }}</a></div>
       {% endfor %}
-      </p>
     </div>
     <div class="aside-categories">
       <p>:pencil: カテゴリ一覧</p>
       {% for category in site.categories %}
         {% capture category_name %}{{ category | first }}{% endcapture %}
-        <div class="aside-categories-item"><a href="{{site.baseurl}}/categories/index#{{category_name}}" class="aside-link">{{ category_name | capitalize }}</a></div>
+        <div class="aside-categories-item">
+          <a href="{{site.baseurl}}/categories/index#{{category_name}}" class="aside-link">
+            {{ category_name | capitalize }}
+          </a>
+        </div>
       {% endfor %}
-      </p>
     </div>
     <div class="aside-tags">
       <p>:pencil: タグ一覧</p>

--- a/_includes/aside.html
+++ b/_includes/aside.html
@@ -14,9 +14,11 @@
       {% for category in site.categories %}
         {% capture category_name %}{{ category | first }}{% endcapture %}
         <div class="aside-categories-item">
-          <a href="{{site.baseurl}}/categories/index#{{category_name}}" class="aside-link">
-            {{ category_name | capitalize }}
-          </a>
+          <ul>
+            <li><a href="{{site.baseurl}}/categories/index#{{category_name}}" class="aside-link">
+              {{ category_name | capitalize }}
+            </a></li>
+          </ul>
         </div>
       {% endfor %}
     </div>

--- a/_includes/aside.html
+++ b/_includes/aside.html
@@ -10,5 +10,13 @@
       {% endfor %}
       </p>
     </div>
+    <div class="aside-categories">
+      <p>:pencil: カテゴリ一覧</p>
+      {% for category in site.categories %}
+        {% capture category_name %}{{ category | first }}{% endcapture %}
+        <div class="aside-categories-item"><a href="{{site.baseurl}}/categories/index#{{category_name}}" class="aside-link">{{ category_name | capitalize }}</a></div>
+      {% endfor %}
+      </p>
+    </div>
   </div>
 </aside>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -23,7 +23,10 @@
               {% endfor %}
             </p>
 
-            <div class="post-content">{{ post.excerpt | strip_html | truncatewords: 200 }}</div>
+            <div class="post-content">{{ post.excerpt | strip_html | truncatewords: 200 }}</div><br>
+              {% for tag in post.tags %}
+                <a href="{{site.baseurl}}/tags/index#{{tag | slugify}}">#{{ tag | capitalize }}</a>
+              {% endfor %}
           </article>
 
           <hr>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -11,7 +11,15 @@
           {% for post in site.posts %}
 
           <article class="post-preview">
-            <p class="post-meta">{{ post.published_at | date: '%Y-%m-%d' }}&nbsp;&nbsp;@{{post.author}}</p>
+            <p class="post-meta">{{ post.published_at | date: '%Y-%m-%d' }}&nbsp;&nbsp;
+            {% if post.author[0] == nil %}
+              @{{ post.author }}
+            {% else %}
+              {% for author in post.author %}
+                @{{ author }}
+              {% endfor %}
+            {% endif %}
+            </p>
             <a href="{{ post.url | prepend: site.baseurl | replace: '//', '/' }}">
               <h1 class="post-title">{{ post.title }}</h1>
             </a>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -27,14 +27,16 @@
             <p>
               Categories : 
               {% for category in post.categories %}
-                <a href="{{site.baseurl}}/categories/index#{{category|slugize}}">{{ category | capitalize }}</a>
+                <a href="{{site.baseurl}}/categories/index#{{ category | slugify }}">{{ category | capitalize }}</a>
               {% endfor %}
             </p>
 
-            <div class="post-content">{{ post.excerpt | strip_html | truncatewords: 200 }}</div><br>
+            <div class="post-content">{{ post.excerpt | strip_html | truncatewords: 200 }}</div>
+            <p>
               {% for tag in post.tags %}
-                <a href="{{site.baseurl}}/tags/index#{{tag | slugify}}">#{{ tag | capitalize }}</a>
+                <a href="{{site.baseurl}}/tags/index#{{ tag | slugify }}">#{{ tag | capitalize }}</a>
               {% endfor %}
+            </p>
           </article>
 
           <hr>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -16,8 +16,14 @@
               <h1 class="post-title">{{ post.title }}</h1>
             </a>
 
-            <div class="post-content">{{ post.excerpt | strip_html | truncatewords: 200 }}</div>
+            <p>
+              Categories : 
+              {% for category in post.categories %}
+                <a href="{{site.baseurl}}/categories/index#{{category|slugize}}">{{ category | capitalize }}</a>
+              {% endfor %}
+            </p>
 
+            <div class="post-content">{{ post.excerpt | strip_html | truncatewords: 200 }}</div>
           </article>
 
           <hr>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -20,21 +20,21 @@
               {% endfor %}
             {% endif %}
             </p>
-            <a href="{{ post.url | prepend: site.baseurl | replace: '//', '/' }}">
+            <a href="{{ post.url | prepend: site.baseurl | replace: '//', '/' }}"class="home-link">
               <h1 class="post-title">{{ post.title }}</h1>
             </a>
 
             <p>
               Categories : 
               {% for category in post.categories %}
-                <a href="{{site.baseurl}}/categories/index#{{ category | slugify }}">{{ category | capitalize }}</a>
+                <a href="{{ site.baseurl }}/categories/index#{{ category | slugify }}"class="home-link">{{ category | capitalize }}</a>
               {% endfor %}
             </p>
 
             <div class="post-content">{{ post.excerpt | strip_html | truncatewords: 200 }}</div>
             <p>
               {% for tag in post.tags %}
-                <a href="{{site.baseurl}}/tags/index#{{ tag | slugify }}">#{{ tag | capitalize }}</a>
+                <a href="{{ site.baseurl }}/tags/index#{{ tag | slugify }}"class="home-link">#{{ tag | capitalize }}</a>
               {% endfor %}
             </p>
           </article>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -1,0 +1,15 @@
+{% include head.html %}
+<body>
+  <div id="container">
+    {% include header.html %}
+    <div id="main">
+      <div id="entry-container">
+      <h2>{{page.title}}</h2>
+        <div class="col-lg-8 col-md-10 mx-auto">
+          {{ content }}
+        </div>
+      </div>
+    </div>
+    {% include footer.html %}
+  </div>
+</body>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -12,7 +12,15 @@
         </h1>
         <section class="entry-inner">
           <div class="inner-content">
-            <div class='author'>書いた人: <a href='https://github.com/{{ page.author }}'>@{{ page.author }}</a></div>
+            <div class='author'>書いた人: 
+            {% if page.author[0] == nil %}
+              <a href='https://github.com/{{ page.author }}'>@{{ page.author }}</a>
+            {% else %}
+              {% for author in page.author %}
+                <a href='https://github.com/{{ author }}'>@{{ author }}</a>
+              {% endfor %}
+            {% endif %}
+            </div>
             {{ content }}
           </div>
           {% include share.html %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -8,13 +8,13 @@
 
         <div class='entry-date'>{{ page.published_at }}</div>
         <h1 class='entry-title'>
-          <a href={{page.permalink}}> {{ page.title }}</a>
+          <a href={{page.permalink}} class='post-link'> {{ page.title }}</a>
         </h1>
         <section class="entry-inner">
           <div class="inner-content">
             <div class='author'>書いた人: 
             {% if page.author[0] == nil %}
-              <a href='https://github.com/{{ page.author }}'>@{{ page.author }}</a>
+              <a href='https://github.com/{{ page.author }}' class='post-link'>@{{ page.author }}</a>
             {% else %}
               {% for author in page.author %}
                 <a href='https://github.com/{{ author }}'>@{{ author }}</a>

--- a/_posts/2021-12-08-jekyll.md
+++ b/_posts/2021-12-08-jekyll.md
@@ -1,0 +1,148 @@
+---
+layout: post
+title: Jekyllを使ったブログにカテゴリ・タグ一覧機能を追加してみた
+published_at: 2021-12-08
+author: [KCSC-Igarashi, saito-site]
+permalink: /2021/12/08-jekyll
+categories: [tech]
+tags: [Ruby, Jekyll]
+---
+
+こんにちは。H2開発グループの@KCSC-Igarashi, @saito-siteです。  
+今回は、今までのブログの記事に元々追加されていたカテゴリ・タグを基に、それぞれの一覧機能を追加しました。  
+その手順を備忘録がてら書いていこうと思います。  
+カテゴリ一覧とタグ一覧は同様な実装をすることになるため、今回はカテゴリ一覧について書きます。  
+
+## 自己紹介
+**@KCSC-Igarashi**  
+　新卒2年目。Ruby/Railsエンジニア。  
+　1年目は防災系システムのwebアプリ開発のプロジェクトでAPI作成等のバックエンド開発を経験。  
+　2年目は通販系サイトのリニューアルプロジェクトにアーキから参画し、フロントエンド開発を経験。  
+　好きなものは日本酒・ソーシャルゲーム。嫌いなものはパクチー。
+
+**@saito-site**  
+　新卒1年目。  
+　5か月間の研修期間を経て、9月～11月は通販系サイトのリニューアルプロジェクトに在籍。  
+　現在は次のプロジェクトまでの勉強期間中。
+
+## カテゴリ一覧ページの実装
+
+カテゴリ一覧を追加するにあたって、以下の4項目について実装します。
+
+1. カテゴリ一覧ページの作成  
+1. 記事一覧のそれぞれの記事表示にその記事のカテゴリを表示  
+1. サイドバーにカテゴリ一覧を表示  
+1. カテゴリ表示部にカテゴリ一覧ページの該当カテゴリへのリンクを付与  
+
+
+### 1 カテゴリ一覧ページの作成
+
+カテゴリ一覧ページでは、すべての記事からカテゴリを取得してカテゴリごとに並べ、該当する記事のタイトルにリンクをつけて表示します。
+
+`category.html`を作成し、以下のコードを記述します。
+{% raw %} 
+```
+
+category.html
+
+---
+layout: page
+permalink: /categories/index
+title: カテゴリ一覧
+---
+
+<div id="archives">
+  {% for category in site.categories %}
+    <div class="archive-group">
+      {% capture category_name %}{{ category | first }}{% endcapture %}
+      <h3 class="category-head"><a name="{{ category_name }}">{{ category_name | capitalize }}</a></h3>
+      {% for post in site.categories[category_name] %}
+        <article class="archive-item">
+          <h4><a href="{{ site.baseurl }}{{ post.url }}">{{post.title}}</a></h4>
+        </article>
+      {% endfor %}
+    </div>
+  {% endfor %}
+</div>
+```
+{% endraw %} 
+
+Front Matter(３つのハイフンで囲まれている部分)で使用するレイアウトやページのurl名を決めています。  
+コード内の\{\{ \}\}と\{％ ％\}で囲まれている部分は、jeckyllで使用されているテンプレート用言語[Liquid](https://shopify.github.io/liquid/){:target="_blank"}の書き方で、  
+前者は内容の出力、後者は論理文の実行を示します。 
+
+### 2 記事一覧のそれぞれの記事表示にその記事のカテゴリを表示
+
+記事一覧は`_layouts/home.html`の`<article>`タグ内に記載されているため、  
+`<article>`タグ内に記事ごとのカテゴリを表示させるようにコードを追加します。  
+
+{% raw %} 
+```
+
+_layouts/home.html
+
+{% for post in site.posts %}
+  <article class="post-preview">
+    <p class="post-meta">{{ post.published_at | date: '%Y-%m-%d' }}&nbsp;&nbsp;@{{post.author}}</p>
+    <a href="{{ post.url | prepend: site.baseurl | replace: '//', '/' }}">
+      <h1 class="post-title">{{ post.title }}</h1>
+    </a>
+
+ +  <p>
+ +    Categories :
+ +    {% for category in post.categories %}
+ +      <a href="{{site.baseurl}}/categories/index#{{ category | slugify }}">{{ category | capitalize }}</a>
+ +    {% endfor %}
+ +  </p>
+
+    <div class="post-content">{{ post.excerpt | strip_html | truncatewords: 200 }}</div>
+  </article>
+
+  <hr>
+{% endfor %}
+```
+{% endraw %} 
+
+### 3 サイドバーにカテゴリ一覧を表示
+
+サイドバーは`_includes/aside.html`に記載されています。  
+こちらにカテゴリ一覧表示のためのコードを追加します。  
+
+{% raw %} 
+```
+
+_includes/aside.html
+
+<div class="aside-categories">
+  <p>:pencil: カテゴリ一覧</p>
+  {% for category in site.categories %}
+    {% capture category_name %}{{ category | first }}{% endcapture %}
+    <div class="aside-categories-item">
+      <a href="{{site.baseurl}}/categories/index#{{category_name}}" class="aside-link">
+        {{ category_name | capitalize }}
+      </a>
+    </div>
+  {% endfor %}
+</div>
+```
+{% endraw %} 
+
+## 感想
+
+**@KCSC-Igarashi**  
+　今まで、RubyのフレームワークはRailsしか触れてこなかったため、今回初めてJekyllに触れてみて改めて違いを認識しました。  
+　カテゴリ一覧機能を追加するにあたり、自分たちで見積もりを立て、実装を行いました。  
+　見積り 3日 ( 調査 　2日、実装 　1日 )  
+　実績 　2日 ( 調査 1.5日、実装 0.5日 )  
+　おおよそ見積り通りに実装が行えたかと思います。  
+　実装に入る前にJekyllはどのようなものか、どうやって実装するかを入念に調査したため、実装自体は半日もかかりませんでした。  
+　新しいものに触れる際に構造を大枠でも理解することが大切だと感じました。  
+
+**@saito-site**  
+　普段使用しているRailsとは違うフレームワークを使用するため、実装に5日(7.5h/日)かかると想定していたものが、  
+　ふたを開けてみれば半分の2.5日で完了するものでした。  
+　ただ今回は先輩のコードを参照することができたため、自分1人の力ではおそらく想定していた日数かかるだろうなという印象を受けました。  
+　まずは1人でも2.5日以内に実装が完了できるように、これからも知識を増やしていきたいです。
+
+
+ケーシーエスキャロット 採用情報は、[こちら](https://www.carrot.co.jp/recruit){:target="_blank"}

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -30,15 +30,48 @@ body {
   text-align: left;
   word-wrap: break-word;
   flex-grow: 0;
+  border-radius: 5px;
 }
 #aside-inner {
 }
+.aside-recent {
+  font-size: 18px;
+  font-weight: 700;
+}
 .aside-recent-item {
   padding-left: 10px;
+  font-size: 16px;
+  font-weight: 500;
+}
+.aside-categories {
+  font-size: 18px;
+  font-weight: 700;
+}
+.aside-categories-item {
+  padding-left: 10px;
+  font-size: 16px;
+  font-weight: 500;
+}
+.aside-tags {
+  font-size: 18px;
+  font-weight: 700;
+}
+.aside-tags-item-container {
+/*  display: flex; */
+}
+.aside-tags-item {
+  padding-left: 10px;
+  font-size: 16px;
+  font-weight: 500;
 }
 .aside-link {
-  /*text-decoration: none; */
+  text-decoration: none;
   color: black;
+  font-size: 16px;
+  font-weight: 500;
+}
+.aside-link:hover {
+  color: darkviolet;
 }
 /* --- END aside.html ---*/
 
@@ -90,6 +123,13 @@ body {
 }
 .post-content {
 }
+.home-link {
+  text-decoration: none;
+  color: black;
+}
+.home-link:hover {
+  color: darkviolet;
+}
 /* --- END home.html ---*/
 /* --- START post.html ---*/
 #entry {
@@ -115,4 +155,25 @@ body {
 
 .author {
 }
+.post-link {
+  text-decoration: none;
+}
 /* --- END post.html ---*/
+/* --- START category.html ---*/
+.category-link {
+  text-decoration: none;
+  color: black;
+}
+.category-link:hover {
+  color: darkviolet;
+}  
+/* --- END category.html ---*/
+/* --- START tag.html ---*/
+.tag-link {
+  text-decoration: none;
+  color: black;
+}
+.tag-link:hover {
+  color: darkviolet;
+}
+/* --- END tag.html ---*/

--- a/category.html
+++ b/category.html
@@ -11,7 +11,7 @@ title: カテゴリ一覧
       <h3 class="category-head"><a name="{{ category_name }}">{{ category_name | capitalize }}</a></h3>
       {% for post in site.categories[category_name] %}
         <article class="archive-item">
-          <h4><a href="{{ site.baseurl }}{{ post.url }}">{{post.title}}</a></h4>
+          :carrot:<a href="{{ site.baseurl }}{{ post.url }}" class="category-link">{{post.title}}</a>
         </article>
       {% endfor %}
     </div>

--- a/category.html
+++ b/category.html
@@ -1,0 +1,19 @@
+---
+layout: page
+permalink: /categories/index
+title: カテゴリ一覧
+---
+
+<div id="archives">
+{% for category in site.categories %}
+  <div class="archive-group">
+    {% capture category_name %}{{ category | first }}{% endcapture %}
+    <h3 class="category-head"><a name="{{ category_name }}">{{ category_name | capitalize }}</a></h3>
+    {% for post in site.categories[category_name] %}
+      <article class="archive-item">
+        <h4><a href="{{ site.baseurl }}{{ post.url }}">{{post.title}}</a></h4>
+      </article>
+    {% endfor %}
+  </div>
+{% endfor %}
+</div>

--- a/category.html
+++ b/category.html
@@ -5,15 +5,15 @@ title: カテゴリ一覧
 ---
 
 <div id="archives">
-{% for category in site.categories %}
-  <div class="archive-group">
-    {% capture category_name %}{{ category | first }}{% endcapture %}
-    <h3 class="category-head"><a name="{{ category_name }}">{{ category_name | capitalize }}</a></h3>
-    {% for post in site.categories[category_name] %}
-      <article class="archive-item">
-        <h4><a href="{{ site.baseurl }}{{ post.url }}">{{post.title}}</a></h4>
-      </article>
-    {% endfor %}
-  </div>
-{% endfor %}
+  {% for category in site.categories %}
+    <div class="archive-group">
+      {% capture category_name %}{{ category | first }}{% endcapture %}
+      <h3 class="category-head"><a name="{{ category_name }}">{{ category_name | capitalize }}</a></h3>
+      {% for post in site.categories[category_name] %}
+        <article class="archive-item">
+          <h4><a href="{{ site.baseurl }}{{ post.url }}">{{post.title}}</a></h4>
+        </article>
+      {% endfor %}
+    </div>
+  {% endfor %}
 </div>

--- a/tag.html
+++ b/tag.html
@@ -10,7 +10,7 @@ title: タグ一覧
       <h3 class="category-head"><a name="{{ tag_name }}">{{ tag_name | capitalize }}</a></h3>
     {% for post in site.tags[tag_name] %}
       <article class="archive-item">
-        <h4><a href="{{ site.baseurl }}{{ post.url }}">{{post.title}}</a></h4>
+        :carrot:<a href="{{ site.baseurl }}{{ post.url }}" class="tag-link">{{post.title}}</a>
       </article>
     {% endfor %}
   </div>

--- a/tag.html
+++ b/tag.html
@@ -1,0 +1,19 @@
+---
+layout: page
+permalink: /tags/index
+title: タグ一覧
+---
+<div id="archives">
+{% for tag in site.tags %}
+  <div class="archive-group">
+    {% capture tag_name %}{{ tag | first }}{% endcapture %}
+      <h3 class="category-head"><a name="{{ tag_name }}">{{ tag_name | capitalize }}</a></h3>
+    {% for post in site.tags[tag_name] %}
+      <article class="archive-item">
+        <h4><a href="{{ site.baseurl }}{{ post.url }}">{{post.title}}</a></h4>
+      </article>
+    {% endfor %}
+  </div>
+{% endfor %}
+</div>
+


### PR DESCRIPTION
<実装内容>  
- タグ一覧のページを作成
- index の記事一覧表示のところに、その記事についているタグの一覧を表示
- index の右側メニューにタグの一覧を表示
- タグ名をクリックしたら、タグ一覧ページの該当のタグの箇所に飛ぶようにする  

以上4項目をカテゴリでも実装
- リンクのデザインを変更