### PR TITLE
最新投稿のサムネイルのサイズを固定

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -163,7 +163,7 @@ body {
 .post-newest-img{
   margin: 0;
   height: 300px;
-  width: 40%;
+  width: 680px;
   background: linear-gradient(-135deg, rgba(63,24,126,0.3), rgba(247,129,191,0.3));
   display: table-cell;
   vertical-align: middle;
@@ -177,6 +177,12 @@ body {
 }
 .post-newest-title {
   margin: 5px 10px;
+}
+
+.post-newest-img img {
+  height: 100%;
+  width: 100%;
+  object-fit: contain;
 }
 
 .post-no-image{


### PR DESCRIPTION
#56 への対応として、最新投稿のサムネイル表示領域のサイズを固定して表示崩れを回避するためのCSS修正を行いました。

タブレット表示等、横幅が狭いときの表示が以前と変わっているため、そのパターンもスクリーンショットを添付しています。
そちらも合わせてご確認をお願いします。

### 横幅1500px/サムネイルサイズ大(#56 で問題になっていた画像)

![after_大サムネ](https://github.com/user-attachments/assets/fb9ee6b7-f727-4f2e-bdf6-85c88f912027)

### 横幅1500px/サムネイルサイズ小(現在の最新投稿のサムネイル)

![after_小サムネ](https://github.com/user-attachments/assets/9849f489-fc8c-4c95-b5dd-20b4d8c304bf)

### 横幅1500px/サムネイル画像なし

![after_サムネなし](https://github.com/user-attachments/assets/93c6c28e-7624-4e74-a24b-da882ddd9a64)

### 横幅750px
#### before
![before_幅750px](https://github.com/user-attachments/assets/1e2ab2c1-05ca-4b7f-949b-b9ce85f64c51)

#### after
![幅750px](https://github.com/user-attachments/assets/b60c7506-706d-4f59-ae54-65437830e354)
