### PR TITLE
記載内容に誤りがあったので修正

### DIFF
--- a/_posts/2024-07-19-rubykaigi2024.md
+++ b/_posts/2024-07-19-rubykaigi2024.md
@@ -120,7 +120,7 @@ img: /assets/images/rubykaigi2024/logo.png
 * 大木： 10年位温まっている課題の話があって、ERBも進化し続けているのを感じました。
 * 工藤： 我々の知らない所で色々頑張ってくださっているんだと感じますね。
 
-* 今野： あ～、それも見たかったです。私はそのとき裏番組でやっていた [Ruby and the World Record Pi Calculation](https://rubykaigi.org/2024/presentations/Yuryu.html#day3) を見ていました。発表者の方は Rails Girls がきっかけでプログラミングの世界に飛び込まれたということで、自分の活動(※Rails Girls Japanのメンバーとしても活動しています)が誰かの飛躍のきっかけになるのかもと思うと、背筋が伸びる思いでした。
+* 今野： あ～、それも見たかったです。私はそのとき裏番組でやっていた [Ruby and the World Record Pi Calculation](https://rubykaigi.org/2024/presentations/Yuryu.html#day3) を見ていました。発表者の@YuryuさんにとってRails Girlsへの参加が大きな転機のひとつであったとのことで、自分の活動(※Rails Girls Japanのメンバーとしても活動しています)が誰かの飛躍のきっかけになるのかもと思うと、背筋が伸びる思いでした。
 * 大木： ギネス記録の更新ですもんね、凄いです。
 
 ### Q: スポンサーブース、ノベルティについて


### PR DESCRIPTION
発表者の方の経歴に誤りがあったことを指摘していただいたので、修正を行いました。

発表時のスライドが公開されているので、この辺りを確認しつつ表現を調整しています。
https://speakerdeck.com/yuryu/ruby-and-the-world-record-pi-calculation?slide=40