### PR TITLE
スマートフォン対応

### DIFF
--- a/_includes/aside.html
+++ b/_includes/aside.html
@@ -5,7 +5,7 @@
     </div>
     <div class="aside-recent">
       <p class="aside-content-title">:pencil: 最近の投稿</p>
-      {% for post in site.posts limit:15 %}
+      {% for post in site.posts limit:5 %}
       <div class="aside-recent-item">
         <p class="post-meta">{{ post.published_at | date: '%Y-%m-%d' }}</p>
         <a href="{{ post.url }}" class="aside-link">{{ post.title }}</a>

--- a/_includes/aside.html
+++ b/_includes/aside.html
@@ -1,4 +1,4 @@
-<aside id="aside">
+<aside id="aside" class="pure-u-1 pure-u-lg-1-5">
   <div>
     <div class="aside-home">
       <a href="{{ site.url }}" class="aside-link">:house: Home</a>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -7,6 +7,11 @@
       {{ site.title }}
     {% endif %}
   </title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/purecss@3.0.0/build/grids-min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/purecss@3.0.0/build/grids-responsive-min.css">
+
   <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}">
   <link rel="stylesheet" href="{{ '/assets/css/syntax.css' | relative_url }}">
   <link rel="icon" href="{{ '/assets/images/favicon.ico' }}" />

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -2,96 +2,102 @@
 <body>
   {% include header.html %}
   <div id="container">
-    <div id="main">
-      <div id="entry-container">
-
-        <div class="col-lg-8 col-md-10 mx-auto">
+    <div id="main" class="pure-g">
+      <div id="entry-container" class="pure-u-lg-4-5">
+        <div class="pure-g">
           {{ content }}
           <!-- Home Post List -->
           <!-- newest-->
-          <article class="post-newest-preview">
-            <div class="post-newest-img">
-              {% if site.posts.first.img %}
-                <img src="{{ site.posts.first.img }}" alt="{{ site.posts.first.title }}" />
-              {% else %}
-                <div class="post-no-image">{{ site.posts.first.title }}</div>
-              {% endif %}
-            </div>
-            <div class="post-newest-content">
-              <p class="post-meta">{{ site.posts.first.published_at | date: '%Y-%m-%d' }}</p>
-              <p class="post-title">
-              <a href="{{ site.posts.first.url | prepend: site.baseurl | replace: '//', '/' }}" class="home-link">
-                <h1 class="post-newest-title">{{ site.posts.first.title }}</h1>
-              </a>
-              <p class="post-meta">
-                {% if site.posts.first.author[0] == nil %}
-                    @{{ site.posts.first.author }}
-                  {% else %}
-                    {% for author in site.posts.first.author %}
-                      @{{ author }}
-                    {% endfor %}
-                  {% endif %}
-              </p>
-
-              <p>
-                  Categories :
-                  {% for category in site.posts.first.categories %}
-                    <a href="{{ site.baseurl }}/categories/index#{{ category | slugify }}"class="categories">{{ category | capitalize }}</a>
-                  {% endfor %}
-                </p>
-
-                <p>{{ site.posts.first.excerpt | strip_html | truncatewords: 200 }}</p>
-
-                <p>
-                  {% for tag in site.posts.first.tags %}
-                     <a href="{{ site.baseurl }}/tags/index#{{ tag | slugify }}"class="tags">{{ tag | capitalize }}</a>
-                  {% endfor %}
-                </p>
-            </div>
-          </article>
-
-          <div class="post-articles">
-          {% for post in site.posts %}
-      	    {% if post != site.posts.first %}
-              <article class="post-preview">
-                <div class="post-img">
-                  {% if post.img %}
-                    <img src="{{ post.img }}" class="post-image" alt="{{ post.title }}" />
-                  {% else %}
-                    <div class="post-no-image">{{ post.title }}</div>
-                  {% endif %}
-                </div>
-                <div class="post-content">
-                  <p class="post-meta">{{ post.published_at | date: '%Y-%m-%d' }}</p>
-                  <a href="{{ post.url | prepend: site.baseurl | replace: '//', '/' }}"class="home-link">
-                    <h2 class="post-title">{{ post.title }}</h2>
+          <div class="pure-u-1">
+            <article class="post-newest-preview">
+              <div class="post-newest-img pure-u-md-1-2">
+                {% if site.posts.first.img %}
+                  <img src="{{ site.posts.first.img }}" alt="{{ site.posts.first.title }}" />
+                {% else %}
+                  <div class="post-no-image">{{ site.posts.first.title }}</div>
+                {% endif %}
+              </div>
+  
+              <div class="post-newest-content pure-u-md-1-2">
+                <div>
+                  <p class="post-meta">{{ site.posts.first.published_at | date: '%Y-%m-%d' }}</p>
+                  <p class="post-title">
+                  <a href="{{ site.posts.first.url | prepend: site.baseurl | replace: '//', '/' }}" class="home-link">
+                    <h1 class="post-newest-title">{{ site.posts.first.title }}</h1>
                   </a>
                   <p class="post-meta">
-                    {% if post.author[0] == nil %}
-                      @{{ post.author }}
+                    {% if site.posts.first.author[0] == nil %}
+                      @{{ site.posts.first.author }}
                     {% else %}
-                      {% for author in post.author %}
+                      {% for author in site.posts.first.author %}
                         @{{ author }}
                       {% endfor %}
                     {% endif %}
                   </p>
-
-                <p>
-                  Categories : 
-                  {% for category in post.categories %}
-                    <a href="{{ site.baseurl }}/categories/index#{{ category | slugify }}"class="categories">{{ category | capitalize }}</a>
-                  {% endfor %}
-                </p>
-
-                <p>
-                  {% for tag in post.tags %}
-                     <a href="{{ site.baseurl }}/tags/index#{{ tag | slugify }}"class="tags">{{ tag | capitalize }}</a>
-                  {% endfor %}
-                </p>
+    
+                  <p>
+                      Categories :
+                      {% for category in site.posts.first.categories %}
+                        <a href="{{ site.baseurl }}/categories/index#{{ category | slugify }}"class="categories">{{ category | capitalize }}</a>
+                      {% endfor %}
+                    </p>
+    
+                    <p>{{ site.posts.first.excerpt | strip_html | truncatewords: 200 }}</p>
+    
+                    <p>
+                      {% for tag in site.posts.first.tags %}
+                         <a href="{{ site.baseurl }}/tags/index#{{ tag | slugify }}"class="tags">{{ tag | capitalize }}</a>
+                      {% endfor %}
+                    </p>  
+                </div>
               </div>
             </article>
-            {% endif %}
-          {% endfor %}
+          </div>
+
+          <div class="post-articles pure-g">
+            {% for post in site.posts %}
+              {% if post != site.posts.first %}
+                <div class="post-wrap pure-u-1 pure-u-sm-1-2 pure-u-lg-1-3">
+                  <article class="post-preview">
+                    <div class="post-img">
+                      {% if post.img %}
+                        <img src="{{ post.img }}" class="post-image" alt="{{ post.title }}" />
+                      {% else %}
+                        <div class="post-no-image">{{ post.title }}</div>
+                      {% endif %}
+                    </div>
+                    <div class="post-content">
+                      <p class="post-meta">{{ post.published_at | date: '%Y-%m-%d' }}</p>
+                      <a href="{{ post.url | prepend: site.baseurl | replace: '//', '/' }}"class="home-link">
+                        <h2 class="post-title">{{ post.title }}</h2>
+                      </a>
+                      <p class="post-meta">
+                        {% if post.author[0] == nil %}
+                          @{{ post.author }}
+                        {% else %}
+                          {% for author in post.author %}
+                            @{{ author }}
+                          {% endfor %}
+                        {% endif %}
+                      </p>
+
+                      <p>
+                        Categories : 
+                        {% for category in post.categories %}
+                          <a href="{{ site.baseurl }}/categories/index#{{ category | slugify }}"class="categories">{{ category | capitalize }}</a>
+                        {% endfor %}
+                      </p>
+
+                      <p>
+                        {% for tag in post.tags %}
+                          <a href="{{ site.baseurl }}/tags/index#{{ tag | slugify }}"class="tags">{{ tag | capitalize }}</a>
+                        {% endfor %}
+                      </p>
+                    </div>
+                  </article>
+                </div>
+              {% endif %}
+            {% endfor %}
           </div>
         </div>
       </div>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -2,8 +2,8 @@
 <body>
   {% include header.html %}
   <div id="container">
-    <div id="main">
-      <div id="entry-container">
+    <div id="main" class="pure-g">
+      <div id="entry-container" class="pure-u-lg-4-5">
       <h2>{{page.title}}</h2>
         <div class="col-lg-8 col-md-10 mx-auto">
           {{ content }}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -2,8 +2,8 @@
 <body>
   {% include header.html %}
   <div id="container">
-    <div id="main">
-      <div id="entry-container">
+    <div id="main" class="pure-g">
+      <div id="entry-container" class="pure-u-lg-4-5">
         <div id="entry">
 
         <div class='entry-date'>{{ page.published_at }}</div>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -47,16 +47,19 @@ body {
 
 /* --- START aside.html ---*/
 #aside {
-  padding: 30px 0px 0px 20px;
+  padding-top: 30px;
+  /*
   width: 300px;
   float: right;
+  flex-grow: 0;
+  */
   font-size: 16px;
   text-align: left;
   word-wrap: break-word;
-  flex-grow: 0;
   border-radius: 5px;
 }
-#aside-inner {
+#aside > div {
+  padding-left: 20px;
 }
 .aside-content-title{
   margin: 15px 0px 10px 0px;
@@ -130,24 +133,17 @@ body {
 /* --- END share.html ---*/
 
 /* --- START post.html/home.html ---*/
-#container {
-  text-align: center;
-  margin: 0 auto;
-  padding: 0 30px;
-  display: flex;
-  flex-direction: column;
-}
-
 #main {
-  margin: 5px 0px 0px 0px;
-  flex-grow: 3;
-  display: flex;
-  flex-direction: row;
+  padding: 0 10px 0 10px;
 }
 
-#entry-container {
+/* 
+
+ #entry-container {
   width: 100%;
 }
+ */
+
 /* --- END post.html/home.html ---*/
 /* --- START home.html ---*/
 .post-newest-preview {
@@ -155,26 +151,31 @@ body {
   padding: 0;
   border: solid 1px;
   border-radius: 5px;
-  margin: 5px 5px 2px 2px;
+  width: 100%;
   height: 300px;
   display: table;
-  width: 100%;
 }
-.post-newest-img{
+.post-newest-img {
   margin: 0;
-  height: 300px;
-  width: 680px;
   background: linear-gradient(-135deg, rgba(63,24,126,0.3), rgba(247,129,191,0.3));
+  /*
   display: table-cell;
+  */
+  height: 300px;
   vertical-align: middle;
   text-align: center;
   font-weight: bold;
 }
 .post-newest-content {
   height: 300px;
-  padding: 5px 10px;
+  /*
   display: table-cell;
+  */
 }
+.post-newest-content > div {
+  padding: 5px 10px;
+}
+
 .post-newest-title {
   margin: 5px 10px;
 }
@@ -189,19 +190,27 @@ body {
   text-align: center;
   width: 100%;
 }
-.post-articles{
-  width: 100%;
-}
+
 .post-preview{
+  margin-top: 8px;
   text-align: left;
-  padding: 0;
   border: solid 1px;
   border-radius: 5px;
-  margin: 5px 5px 2px 2px;
-  width: 340px;
   height: 480px;
-  float: left;
 }
+
+@media screen and (min-width: 64em) {
+  .post-articles .post-wrap:not(:nth-child(3n)) .post-preview {
+    margin-right: 8px;
+  }
+}
+
+@media screen and (min-width: 35.5em) and (max-width: 63.99em) {
+  .post-articles .post-wrap:not(:nth-child(2n)) .post-preview {
+    margin-right: 8px;
+  }  
+}
+
 .post-img{
   margin: 0;
   height: 200px;
@@ -227,10 +236,10 @@ body {
   font-size: 20px;
 }
 .post-content {
-  height: 300px;
+  /* height: 300px; */
   padding: 5px 10px;
   display: inline-block;
-  width: 100%;
+  /* width: 80%; */
 }
 .home-title-link{
   text-decoration: none;
@@ -259,7 +268,8 @@ body {
 .entry-title {
   margin: 0px;
 } 
-.entry-inner {
+.entry-inner img {
+  max-width: 100%;
 }
 .inner-content {
 }

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -147,7 +147,17 @@ body {
   vertical-align: middle;
   text-align: center;
   font-weight: bold;
+  position: relative;
 }
+
+.post-newest-img .post-no-image {
+  position: absolute;
+  font-size: 28px;
+  top: 50%;
+  left: 50%;
+  transform: translateY(-50%) translateX(-50%);
+}
+
 .post-newest-content {
   height: 300px;
 }

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -48,11 +48,6 @@ body {
 /* --- START aside.html ---*/
 #aside {
   padding-top: 30px;
-  /*
-  width: 300px;
-  float: right;
-  flex-grow: 0;
-  */
   font-size: 16px;
   text-align: left;
   word-wrap: break-word;
@@ -89,9 +84,6 @@ body {
 .aside-tags {
   font-size: 18px;
   font-weight: 700;
-}
-.aside-tags-item-container {
-/*  display: flex; */
 }
 .aside-tags-item {
   padding-left: 10px;
@@ -137,13 +129,6 @@ body {
   padding: 0 10px 0 10px;
 }
 
-/* 
-
- #entry-container {
-  width: 100%;
-}
- */
-
 /* --- END post.html/home.html ---*/
 /* --- START home.html ---*/
 .post-newest-preview {
@@ -158,9 +143,6 @@ body {
 .post-newest-img {
   margin: 0;
   background: linear-gradient(-135deg, rgba(63,24,126,0.3), rgba(247,129,191,0.3));
-  /*
-  display: table-cell;
-  */
   height: 300px;
   vertical-align: middle;
   text-align: center;
@@ -168,9 +150,6 @@ body {
 }
 .post-newest-content {
   height: 300px;
-  /*
-  display: table-cell;
-  */
 }
 .post-newest-content > div {
   padding: 5px 10px;
@@ -236,10 +215,8 @@ body {
   font-size: 20px;
 }
 .post-content {
-  /* height: 300px; */
   padding: 5px 10px;
   display: inline-block;
-  /* width: 80%; */
 }
 .home-title-link{
   text-decoration: none;

--- a/category.html
+++ b/category.html
@@ -12,8 +12,9 @@ title: カテゴリ一覧
         <a name="{{ category_name }}" class="category-head">:carrot:{{ category_name | capitalize }}</a>
       </h3>
 
-      <div class="post-articles">
+      <div class="post-articles pure-g">
         {% for post in site.categories[category_name] %}
+        <div class="post-wrap pure-u-1 pure-u-sm-1-2 pure-u-lg-1-3">
           <article class="post-preview">
             <div class="post-img">
               {% if post.img %}
@@ -50,6 +51,7 @@ title: カテゴリ一覧
               </p>
             </div>
           </article>
+        </div>
         {% endfor %}
       </div>
     </div>

--- a/tag.html
+++ b/tag.html
@@ -9,8 +9,9 @@ title: タグ一覧
     {% capture tag_name %}{{ tag | first }}{% endcapture %}
       <h3 class="category-head"><a name="{{ tag_name }}" class="tags">{{ tag_name | capitalize }}</a></h3>
 
-    <div class="post-articles">
+    <div class="post-articles pure-g">
       {% for post in site.tags[tag_name] %}
+      <div class="post-wrap pure-u-1 pure-u-sm-1-2 pure-u-lg-1-3">
         <article class="post-preview">
           <div class="post-img">
             {% if post.img %}
@@ -47,6 +48,7 @@ title: タグ一覧
             </p>
           </div>
         </article>
+      </div>
       {% endfor %}
     </div>
   </div>


### PR DESCRIPTION
#42 への対応として、[Pure.css](https://purecss.io/)を部分的に導入して
各ページをレスポンシブ表示するように修正しました。

併せて、最新投稿のリストを15件から5件表示に修正しました。

表示例として、トップページのスクリーンショットを添付します。

## 横幅1400px (>= 1024px)

現状の表示とほぼ同じ

<img src="https://github.com/user-attachments/assets/503a744d-220a-4ff0-a0f4-5ab226890fa0" width="320">

## 横幅1000px (>= 768px) 

サイドメニューが下部に移動、過去の記事が2列表示に切り替わる

<img src="https://github.com/user-attachments/assets/39560fc2-efa7-468d-968b-a5dd1c5ec00f" width="320">

## 横幅700px (>= 568px) 

最新記事の表示(サムネとタイトル等)が横並びから横並びに切り替わる

<img src="https://github.com/user-attachments/assets/2c7ef992-3088-4095-a60e-ac1095f72c30" width="320">

## 横幅500px (< 568px) 

過去の記事が1列表示に切り替わる

<img src="https://github.com/user-attachments/assets/e1442cb5-300d-4760-a853-b3efb33d772d" width="320">
