### PR TITLE
#62 サイドメニューに会社リンクを追加

### DIFF
--- a/_includes/aside.html
+++ b/_includes/aside.html
@@ -3,6 +3,11 @@
     <div class="aside-home">
       <a href="{{ site.url }}" class="aside-link">:house: Home</a>
     </div>
+    <div class="aside-company">
+      <a href="https://www.carrot.co.jp/" class="aside-link">
+        <img src="{{ '/assets/images/logo-small.png' }}" alt="KCS Carrot logo">株式会社ケーシーエスキャロット
+      </a>
+    </div>
     <div class="aside-recent">
       <p class="aside-content-title">:pencil: 最近の投稿</p>
       {% for post in site.posts limit:5 %}

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -60,6 +60,17 @@ body {
   margin: 15px 0px 10px 0px;
   border-bottom: solid 1px black;
 }
+
+.aside-company{
+  font-size: 18px;
+  font-weight: 700;
+}
+
+.aside-company img {
+  max-width: 20px;
+  margin: 5px 5px -3px 0;
+}
+
 .aside-recent {
   font-size: 18px;
   font-weight: 700;


### PR DESCRIPTION
#62 対応
サイドメニューに会社のWebページのリンクを追加しました

<img width="597" height="402" alt="image" src="https://github.com/user-attachments/assets/028df8a4-1ca0-4059-bca1-52b724a1b048" />
