### PR TITLE
トップページのリード文のレイアウトを修正

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -9,7 +9,7 @@
           <!-- Home Post List -->
           <!-- newest-->
           <div class="pure-u-1">
-            <article class="post-newest-preview">
+            <article class="post-newest-preview" class="pure-g">
               <div class="post-newest-img pure-u-md-1-2">
                 {% if site.posts.first.image != '/assets/images/ogp.png' %}
                   <img src="{{ site.posts.first.image }}" alt="{{ site.posts.first.title }}" />
@@ -19,37 +19,33 @@
               </div>
   
               <div class="post-newest-content pure-u-md-1-2">
-                <div>
-                  <p class="post-meta">{{ site.posts.first.published_at | date: '%Y-%m-%d' }}</p>
-                  <p class="post-title">
+                <p class="post-meta">{{ site.posts.first.published_at | date: '%Y-%m-%d' }}</p>
+                <p class="post-title">
                   <a href="{{ site.posts.first.url | prepend: site.baseurl | replace: '//', '/' }}" class="home-link">
-                    <h1 class="post-newest-title">{{ site.posts.first.title }}</h1>
+                    <h2 class="post-newest-title">{{ site.posts.first.title }}</h2>
                   </a>
-                  <p class="post-meta">
-                    {% if site.posts.first.author[0] == nil %}
-                      @{{ site.posts.first.author }}
-                    {% else %}
-                      {% for author in site.posts.first.author %}
-                        @{{ author }}
-                      {% endfor %}
-                    {% endif %}
-                  </p>
-    
-                  <p>
-                      Categories :
-                      {% for category in site.posts.first.categories %}
-                        <a href="{{ site.baseurl }}/categories/index#{{ category | slugify }}"class="categories">{{ category | capitalize }}</a>
-                      {% endfor %}
-                    </p>
-    
-                    <p>{{ site.posts.first.excerpt | strip_html | truncatewords: 200 }}</p>
-    
-                    <p>
-                      {% for tag in site.posts.first.tags %}
-                         <a href="{{ site.baseurl }}/tags/index#{{ tag | slugify }}"class="tags">{{ tag | capitalize }}</a>
-                      {% endfor %}
-                    </p>  
-                </div>
+                </p>
+                <p class="post-meta">
+                  {% if site.posts.first.author[0] == nil %}
+                    @{{ site.posts.first.author }}
+                  {% else %}
+                    {% for author in site.posts.first.author %}
+                      @{{ author }}
+                    {% endfor %}
+                  {% endif %}
+                </p>
+                <p>
+                  Categories :
+                  {% for category in site.posts.first.categories %}
+                    <a href="{{ site.baseurl }}/categories/index#{{ category | slugify }}"class="categories">{{ category | capitalize }}</a>
+                  {% endfor %}
+                </p>
+                <div class="post-newest-intro">{{ site.posts.first.excerpt | strip_html }}</div>
+                <div class="post-newest-tag">
+                  {% for tag in site.posts.first.tags %}
+                      <a href="{{ site.baseurl }}/tags/index#{{ tag | slugify }}"class="tags">{{ tag | capitalize }}</a>
+                  {% endfor %}
+                </div>  
               </div>
             </article>
           </div>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -170,10 +170,16 @@ body {
 }
 
 .post-newest-content {
+  box-sizing: border-box;
   height: 300px;
-}
-.post-newest-content > div {
   padding: 5px 10px;
+}
+
+@media screen and (min-width: 47em) {
+  .post-newest-content {
+    /* Firefoxの場合だけ、50%だと崩れるので苦肉の策 */
+    width: 49.3%;
+  }
 }
 
 .post-newest-title {
@@ -184,6 +190,26 @@ body {
   height: 100%;
   width: 100%;
   object-fit: contain;
+}
+
+.post-newest-intro {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  line-clamp: 2;
+  -webkit-line-clamp: 2;
+}
+
+@media screen and (min-width: 83em) {
+  .post-newest-intro {
+    line-clamp: 3;
+    -webkit-line-clamp: 3;
+  }
+}
+
+.post-newest-tag {
+  margin-top: 8px;
 }
 
 .post-no-image{


### PR DESCRIPTION
## 作業の内容

#104 の対応として、トップページで最新記事のリード文が枠をはみ出して表示していたため修正を実施しました。

line-clampプロパティについては、いずれのブラウザも `-webkit-` prefixが必要なようでした。

* https://developer.mozilla.org/ja/docs/Web/CSS/Reference/Properties/line-clamp
* https://caniuse.com/?search=-webkit-line-clamp

また、作業中にFirefoxでの表示崩れが確認できたため、そちらも合わせて修正を行っています。

## 特に確認してほしいこと

以下にスクリーンショットを添付します。

(横幅375px/iPhone SE表示イメージ)
<img width="323" height="574" alt="image" src="https://github.com/user-attachments/assets/9e67bc79-6898-4de5-82ed-56cbf5ea0fe3" />

(横幅1045px)
<img width="1045" height="813" alt="image" src="https://github.com/user-attachments/assets/2fd3f757-900a-4ca8-82d4-5d26318d17c6" />

(Firefox)
<img width="1099" height="755" alt="image" src="https://github.com/user-attachments/assets/be2fbbfb-2e3d-4a87-b56d-31f8cfe453e7" />

(参考:修正前のFirefox表示)

<img width="1099" height="755" alt="image" src="https://github.com/user-attachments/assets/64594be1-4900-4f24-ba40-8a6a13becfd9" />

## 備考

特になし