### PR TITLE
対象Rubyバージョンを 3.2 以上に変更

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.1.4
+FROM ruby:3.2.10
 
 WORKDIR /app
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-ruby '>= 3.1'
+ruby '>= 3.2'
 
 gem "github-pages", group: :jekyll_plugins
 


### PR DESCRIPTION
## 目的
nokogiri 1.19.1 にしたことにより、Ruby 3.2 以上を要するため
#116 

## 変更内容
- 対象Rubyバージョンを3.1系以上から3.2系以上に変更
- Dockerコンテナイメージを Ruby 3.1系から3.2系に変更

## 備考
Ruby3.2.10 はここを見て選びました
https://hub.docker.com/_/ruby